### PR TITLE
added inline styles for height and width where tailwind brackets were…

### DIFF
--- a/app/components/About 2.tsx
+++ b/app/components/About 2.tsx
@@ -105,8 +105,9 @@ export default function About() {
         {/* Hero section */}
         <div className="relative isolate -z-10">
           <svg
+            style={{height: '64rem'}}
             aria-hidden="true"
-            className="absolute inset-x-0 top-0 -z-10 h-[64rem] w-full stroke-gray-200 [mask-image:radial-gradient(32rem_32rem_at_center,white,transparent)]"
+            className="absolute inset-x-0 top-0 -z-10 w-full stroke-gray-200 [mask-image:radial-gradient(32rem_32rem_at_center,white,transparent)]"
           >
             <defs>
               <pattern
@@ -139,18 +140,22 @@ export default function About() {
           >
             <div
               style={{
+                width: '50.0625rem',
                 clipPath:
                   'polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%)',
               }}
-              //   className="aspect-[801/1036] w-[50.0625rem] bg-gradient-to-tr from-[#b6b6b6] to-[#5b5b5b] opacity-30"
-              className="aspect-[801/1036] w-[50.0625rem] bg-gradient-to-tr from-[#eaa9c4] to-[#ec79ea] opacity-30"
+              //   className="aspect-[801/1036]  bg-gradient-to-tr from-[#b6b6b6] to-[#5b5b5b] opacity-30"
+              className="aspect-[801/1036] bg-gradient-to-tr from-[#eaa9c4] to-[#ec79ea] opacity-30"
             />
           </div>
           <div className="overflow-hidden">
             <div className="mx-auto max-w-7xl px-6 pb-32 pt-36 sm:pt-60 lg:px-8 lg:pt-32">
               <div className="mx-auto max-w-2xl gap-x-14 lg:mx-0 lg:flex lg:max-w-none lg:items-center">
                 <div className="relative w-full lg:max-w-xl lg:shrink-0 xl:max-w-2xl">
-                  <h1 style={{fontSize:'1.5rem'}} className="text-pretty font-semibold tracking-tight text-gray-900 ">
+                  <h1
+                    style={{fontSize: '1.5rem'}}
+                    className="text-pretty font-semibold tracking-tight text-gray-900 "
+                  >
                     What is Internal War?
                   </h1>
                   <p
@@ -299,8 +304,9 @@ export default function About() {
         <div className="relative isolate -z-10 mt-32 sm:mt-48">
           <div className="absolute inset-x-0 top-1/2 -z-10 flex -translate-y-1/2 justify-center overflow-hidden [mask-image:radial-gradient(50%_45%_at_50%_55%,white,transparent)]">
             <svg
+              style={{height: '40rem', width: '80rem'}}
               aria-hidden="true"
-              className="h-[40rem] w-[80rem] flex-none stroke-gray-200"
+              className="flex-none stroke-gray-200"
             >
               <defs>
                 <pattern

--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -105,8 +105,9 @@ export default function About() {
         {/* Hero section */}
         <div className="relative isolate -z-10">
           <svg
+            style={{height: '64rem'}}
             aria-hidden="true"
-            className="absolute inset-x-0 top-0 -z-10 h-[64rem] w-full stroke-gray-200 [mask-image:radial-gradient(32rem_32rem_at_center,white,transparent)]"
+            className="absolute inset-x-0 top-0 -z-10 w-full stroke-gray-200 [mask-image:radial-gradient(32rem_32rem_at_center,white,transparent)]"
           >
             <defs>
               <pattern
@@ -139,18 +140,22 @@ export default function About() {
           >
             <div
               style={{
+                width: '50.0625rem',
                 clipPath:
                   'polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%)',
               }}
-              //   className="aspect-[801/1036] w-[50.0625rem] bg-gradient-to-tr from-[#b6b6b6] to-[#5b5b5b] opacity-30"
-              className="aspect-[801/1036] w-[50.0625rem] bg-gradient-to-tr from-[#eaa9c4] to-[#ec79ea] opacity-30"
+              //   className="aspect-[801/1036] bg-gradient-to-tr from-[#b6b6b6] to-[#5b5b5b] opacity-30"
+              className="aspect-[801/1036] bg-gradient-to-tr from-[#eaa9c4] to-[#ec79ea] opacity-30"
             />
           </div>
           <div className="overflow-hidden">
             <div className="mx-auto max-w-7xl px-6 pb-32 pt-36 sm:pt-60 lg:px-8 lg:pt-32">
               <div className="mx-auto max-w-2xl gap-x-14 lg:mx-0 lg:flex lg:max-w-none lg:items-center">
                 <div className="relative w-full lg:max-w-xl lg:shrink-0 xl:max-w-2xl">
-                  <h1 style={{fontSize:'1.5rem'}} className="text-pretty font-semibold tracking-tight text-gray-900 ">
+                  <h1
+                    style={{fontSize: '1.5rem'}}
+                    className="text-pretty font-semibold tracking-tight text-gray-900 "
+                  >
                     What is Internal War?
                   </h1>
                   <p
@@ -299,8 +304,9 @@ export default function About() {
         <div className="relative isolate -z-10 mt-32 sm:mt-48">
           <div className="absolute inset-x-0 top-1/2 -z-10 flex -translate-y-1/2 justify-center overflow-hidden [mask-image:radial-gradient(50%_45%_at_50%_55%,white,transparent)]">
             <svg
+              style={{height: '40rem', width: '80rem'}}
               aria-hidden="true"
-              className="h-[40rem] w-[80rem] flex-none stroke-gray-200"
+              className="flex-none stroke-gray-200"
             >
               <defs>
                 <pattern

--- a/app/components/CartMain.tsx
+++ b/app/components/CartMain.tsx
@@ -27,9 +27,6 @@ export function CartMain({layout, cart: originalCart}: CartMainProps) {
     Boolean(cart?.discountCodes?.filter((code) => code.applicable)?.length);
   const className = `cart-main ${withDiscount ? 'with-discount' : ''}`;
   const cartHasItems = cart?.totalQuantity! > 0;
-  if (cart.isOptimistic) {
-    console.log(cart.totalQuantity, ' <-- optimistic cart.totalQuantity');
-  } else console.log(cart.totalQuantity, ' <-- regualr cart (non opt)');
   return (
     <div className={className + ' mt-20'}>
       <CartEmpty hidden={linesCount} layout={layout} />

--- a/app/components/CartMain.tsx
+++ b/app/components/CartMain.tsx
@@ -1,5 +1,5 @@
 import {useOptimisticCart} from '@shopify/hydrogen';
-import {Link} from '@remix-run/react';
+import {Link, useFetcher} from '@remix-run/react';
 import type {CartApiQueryFragment} from 'storefrontapi.generated';
 import {useAside} from '~/components/Aside';
 import {CartLineItem} from '~/components/CartLineItem';
@@ -27,7 +27,9 @@ export function CartMain({layout, cart: originalCart}: CartMainProps) {
     Boolean(cart?.discountCodes?.filter((code) => code.applicable)?.length);
   const className = `cart-main ${withDiscount ? 'with-discount' : ''}`;
   const cartHasItems = cart?.totalQuantity! > 0;
-
+  if (cart.isOptimistic) {
+    console.log(cart.totalQuantity, ' <-- optimistic cart.totalQuantity');
+  } else console.log(cart.totalQuantity, ' <-- regualr cart (non opt)');
   return (
     <div className={className + ' mt-20'}>
       <CartEmpty hidden={linesCount} layout={layout} />
@@ -51,7 +53,19 @@ function CartEmpty({
   hidden: boolean;
   layout?: CartMainProps['layout'];
 }) {
+  const fetcher = useFetcher();
   const {close} = useAside();
+  const handleNavigateToCollections = async () => {
+    close();
+
+    // Trigger fetcher to load the cart from the server
+    fetcher.load('/cart'); // Replace '/cart' with the endpoint for loading your cart
+
+    // Use a short delay to wait for fetcher to complete (optional)
+    setTimeout(() => {
+      console.log(fetcher.data, '<-- Fetched cart data'); // Log the cart data
+    }, 1000); // Adjust the delay as needed
+  };
   return (
     <div className="newsreader" hidden={hidden}>
       <br />
@@ -60,14 +74,15 @@ function CartEmpty({
         some bold new pieces.
       </p>
       <br />
-      <Link to="/collections" onClick={close} prefetch="viewport">
-        <button
-          type="button"
-          className=" bg-neutral-800 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-neutral-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-        >
-          Continue shopping →
-        </button>
-      </Link>
+      {/* when i navigate to a new page, i need to ensure the cart stays updated */}
+
+      <button
+        onClick={close}
+        type="button"
+        className=" bg-neutral-800 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-neutral-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+      >
+        Continue shopping →
+      </button>
     </div>
   );
 }

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -152,9 +152,10 @@ export function DropdownHeaderMenuSqrHalf({
 
   return (
     <div
+      style={{height: '48.75%'}}
       onMouseEnter={() => setShowShopBtn(true)}
       onMouseLeave={() => setShowShopBtn(false)}
-      className=" h-[48.75%] bg-neutral-300 cursor-pointer relative"
+      className="  bg-neutral-300 cursor-pointer relative"
     >
       <Image className="w-full h-full object-contain" src={img} alt="" />
       <ShopBtnDropdownNav actionDescription={null} url={url} />
@@ -193,8 +194,9 @@ export function DropdownHeaderMenu() {
     return <></>;
   return (
     <div
+      style={{height: '20rem'}}
       onMouseLeave={() => setShowDropdown(false)}
-      className="hidden md:flex w-full h-[20rem] px-20 py-2 bg-neutral-100 flex justify-start gap-2 absolute top-24 left-0"
+      className="hidden md:flex w-full px-20 py-2 bg-neutral-100 justify-start gap-2 absolute top-24 left-0"
     >
       {/* col 1 */}
       <DropdownHeaderMenuSqrFull

--- a/app/components/ProductForm.tsx
+++ b/app/components/ProductForm.tsx
@@ -45,18 +45,14 @@ type ProductOptionValueCustom = {
 };
 interface Option {
   name: string;
-  optionValues: DeepObject[]; // Array of objects with unknown structure
+  // optionValues: DeepObject[]; // Array of objects with unknown structure
   values: ProductOptionValueCustom[];
 }
-// temp deleting option?.optionValues[0]
 export const SizePicker = ({option}: {option: Option}) => {
   const [selectedSize, setSelectedSize] = useState(option?.values[0] || 'S');
+
   return (
     <div>
-      <div className="flex items-center justify-start gap-12">
-        <h2 className="text-sm font-medium text-gray-900">{option.name}</h2>
-      </div>
-
       <fieldset aria-label={`Choose a ${option.name}`} className="mt-3">
         <RadioGroup
           value={selectedSize}

--- a/app/components/ProductList.tsx
+++ b/app/components/ProductList.tsx
@@ -56,7 +56,6 @@ export const ProductCard: React.FC<ProductCardProps> = ({
                 {product.title}
               </a>
             </h3>
-            {/* <p className="mt-1 text-sm text-gray-500">{product.color}</p> */}
           </div>
           <p className="text-sm font-medium text-gray-900">${formattedPrice}</p>
         </div>
@@ -71,7 +70,6 @@ export const ProductCard: React.FC<ProductCardProps> = ({
           return (
             <>
               <div className="mt-4">
-                <div>{option.name}</div>
                 <div className="flex gap-4 items-center  my-3 relative   justify-center ">
                   {option.values.map(({value, isAvailable, to, isActive}) => (
                     <Link

--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -72,7 +72,7 @@ interface HeroVideoProps {
 }
 function HeroVideo({url}: HeroVideoProps) {
   return (
-    <div className="hero-video w-screen max-h-[50rem] relative">
+    <div style={{maxHeight: '50rem'}} className="hero-video w-screen relative">
       {/* //TODO change the fonts later */}
       <div className="absolute left-1/5 top-1/2 flex flex-col gap-4 justify-center items-start">
         <h2 className="uppercase tracking-widest font-light flex">
@@ -80,7 +80,7 @@ function HeroVideo({url}: HeroVideoProps) {
         </h2>
         <h3 className="uppercase text-3xl">slogan here</h3>
         <span className=" capitalize">shop our latest collection now!</span>
-        <Link  to={'/collections'}>
+        <Link to={'/collections'}>
           <button
             type="button"
             className=" bg-neutral-900 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-neutral-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-700 uppercase min-w-40 mt-6"
@@ -90,7 +90,8 @@ function HeroVideo({url}: HeroVideoProps) {
         </Link>
       </div>
       <video
-        className="max-h-[50rem] w-screen object-center object-cover relative -z-10"
+        style={{maxHeight: '50rem'}}
+        className=" w-screen object-center object-cover relative -z-10"
         src={url}
         width="100%"
         autoPlay

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -81,7 +81,7 @@ export async function action({request, context}: ActionFunctionArgs) {
     status = 303;
     headers.set('Location', redirectTo);
   }
-
+  console.log(cartResult.totalQuantity, ' <-- cart result: server');
   return json(
     {
       cart: cartResult,
@@ -97,7 +97,6 @@ export async function action({request, context}: ActionFunctionArgs) {
 export default function Cart() {
   const rootData = useRouteLoaderData<RootLoader>('root');
   if (!rootData) return null;
-
   return (
     <div className="cart">
       <h1>Cart</h1>

--- a/app/routes/($locale).collections._index.tsx
+++ b/app/routes/($locale).collections._index.tsx
@@ -55,7 +55,10 @@ export default function Collections() {
         </h1>
         <div className="-my-2">
           <div className="flex justify-center relative box-content  py-2 mb-12 md:mb-24 ">
-            <div className="  grid grid-cols-1 md:grid-cols-3 w-full max-w-[80rem] gap-6">
+            <div
+              style={{maxWidth: '80rem'}}
+              className="  grid grid-cols-1 md:grid-cols-3 w-full gap-6"
+            >
               {collections.nodes
                 .slice(1)
                 .map((collection: CollectionFragment, index: number) => (

--- a/storefrontapi.generated.d.ts
+++ b/storefrontapi.generated.d.ts
@@ -781,6 +781,7 @@ export type ProductVariantFragment = Pick<
   unitPrice?: StorefrontAPI.Maybe<
     Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>
   >;
+
 };
 
 export type ProductFragment = Pick<


### PR DESCRIPTION
… used for custom values. I did this since I sometimes experience where these custom bracket values do not make it into production since purgecss cannot recognize them as utility classes/ styles in the final html. Also removed the variant option names for products. Any products with multiple variant options (ex color and size) does not properly select the user selected variant when navigating to the product page. Will look at logic for that and ensure it works for a dynamic value of variant options